### PR TITLE
Fixed a typo in Section 6.10.

### DIFF
--- a/draft-tuexen-tsvwg-rfc4960-errata.xml
+++ b/draft-tuexen-tsvwg-rfc4960-errata.xml
@@ -604,7 +604,7 @@ New text: (Section 6.10)
 
 An endpoint bundles chunks by simply including multiple chunks in one
 outbound SCTP packet.  The total size of the resultant IP datagram,
-including the SCTP packet and IP headers, MUST be less that or equal
+including the SCTP packet and IP headers, MUST be less than or equal
 to the current Path MTU.
 </artwork>
 </figure>


### PR DESCRIPTION
There was a typo in Section 6.10 of RFC4960 (not present in 2960 because of different wording). Since this new document is addressing a blank line issue for Section 6.10, I thought it'd be a good time to fix the typo (or at least point it out).
